### PR TITLE
Update qwc-front.php

### DIFF
--- a/modules/woo-commerce/qwc-front.php
+++ b/modules/woo-commerce/qwc-front.php
@@ -28,6 +28,7 @@ function qwc_add_filters_front() {
         'woocommerce_order_subtotal_to_display'             => 20,
         'woocommerce_page_title'                            => 20,
         'woocommerce_product_title'                         => 20,
+        'woocommerce_product_get_name'                      => 20,
         'woocommerce_rate_label'                            => 20,
         'woocommerce_short_description'                     => 20,
         'woocommerce_variation_option_name'                 => 20,


### PR DESCRIPTION
Add the  'woocommerce_product_get_name' filter to the $use_filters array to translate the product name in the woocommerce widgets